### PR TITLE
cycle fix

### DIFF
--- a/MGTemplateStandardMarkers.m
+++ b/MGTemplateStandardMarkers.m
@@ -73,7 +73,7 @@
 
 @implementation MGTemplateStandardMarkers
 {
-	MGTemplateEngine *engine; // weak ref
+	__weak MGTemplateEngine *engine; // weak ref
 	NSMutableArray *forStack;
 	NSMutableArray *sectionStack;
 	NSMutableArray *ifStack;


### PR DESCRIPTION
Tagging MGTemplateStandardMarkers->engine ivar as __weak. 
Without the
__weak tag, engine is a strong reference, and a strong reference cycle is created, and any allocated MGTemplateEngine objects will never be deallocated.