### PR TITLE
Fix missing % in test - if clause not closed.

### DIFF
--- a/MGTemplateEngineTests/MGTemplateEngineTests.m
+++ b/MGTemplateEngineTests/MGTemplateEngineTests.m
@@ -170,7 +170,7 @@
 }
 
 - (void) testNestedIf {
-    NSString *result = [engine_ processTemplate: @"{% if false %}level1{% if false}level2{% /if %}level1{% /if %}level0"
+    NSString *result = [engine_ processTemplate: @"{% if false %}level1{% if false %}level2{% /if %}level1{% /if %}level0"
                                   withVariables: [NSDictionary dictionaryWithObject: [NSArray array] forKey: @"foo"]];
     XCTAssertEqualObjects(@"level0", result, @"");
     XCTAssertNil([delegate_ lastError], @"");

--- a/MGTemplateEngineTests/MGTemplateEngineTests.m
+++ b/MGTemplateEngineTests/MGTemplateEngineTests.m
@@ -277,14 +277,12 @@
 }
 
 - (void) testMultiWordDefaultFound {
-    // Not documented, but let's add tests anyway.
     NSString *result = [engine_ processTemplate: @"{{value | default: 1601 Walnut St. Minneapolis}}"
                                   withVariables: [NSDictionary dictionaryWithObject: @"" forKey: @"value"]];
     XCTAssertEqualObjects(@"1601 Walnut St. Minneapolis ", result, @"");
     XCTAssertEqualObjects(nil, [delegate_ lastError], @"");
 }
 - (void) testDefaultWithQuotes {
-    // Not documented, but let's add tests anyway.
     NSString *result = [engine_ processTemplate: @"{{value | default: \"1601 Walnut St. Minneapolis\"}}"
                                   withVariables: [NSDictionary dictionaryWithObject: @"" forKey: @"value"]];
     XCTAssertEqualObjects(@"1601 Walnut St. Minneapolis ", result, @"");

--- a/MGTemplateStandardMarkers.m
+++ b/MGTemplateStandardMarkers.m
@@ -238,9 +238,9 @@
 			// Check to see if this was a block with an invalid looping condition.
 			NSNumber *disabledOutput = (NSNumber *)[frame objectForKey:FOR_STACK_DISABLED_OUTPUT];
 			if (disabledOutput && [disabledOutput boolValue]) {
-				*outputEnabled = YES;
-				*blockEnded = YES;
+                *blockEnded = YES;
 				[forStack removeLastObject];
+                *outputEnabled = ![[[forStack lastObject] objectForKey: FOR_STACK_DISABLED_OUTPUT] boolValue];
 			}
 			
 			// This is the same loop that's on top of our stack. Check to see if we need to loop back.


### PR DESCRIPTION
Add missing percent in an if clause in testNestedIf test.  This change fixes a broken test.

Github's diff viewer seems to be a little screwy with the percent characters; there should only be a single character change in this commit.
